### PR TITLE
feat: lock down firestore rules + add firebase.json

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,6 @@
+{
+  "firestore": {
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
+  }
+}

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,4 @@
+{
+  "indexes": [],
+  "fieldOverrides": []
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,125 @@
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    // ─── Helpers ─────────────────────────────────────────────────────────────
+    function isSignedIn() {
+      return request.auth != null;
+    }
+
+    function isOwner(uid) {
+      return isSignedIn() && request.auth.uid == uid;
+    }
+
+    function isAdmin() {
+      return isSignedIn()
+        && request.auth.token.email != null
+        && exists(/databases/$(database)/documents/admins/$(request.auth.token.email))
+        && get(/databases/$(database)/documents/admins/$(request.auth.token.email)).data.isAdmin == true;
+    }
+
+    // ─── users/{uid} ─────────────────────────────────────────────────────────
+    // A user can only read/write their own profile. Admins can read/update.
+    match /users/{uid} {
+      allow read:   if isOwner(uid) || isAdmin();
+      allow create: if isOwner(uid);
+      allow update: if isOwner(uid) || isAdmin();
+      allow delete: if isAdmin();
+    }
+
+    // ─── operators/{uid} ─────────────────────────────────────────────────────
+    // Operator owns own doc. Admins can read all (for KYC review).
+    // Operators cannot read other operators' profiles.
+    match /operators/{uid} {
+      allow read:   if isOwner(uid) || isAdmin();
+      allow create: if isOwner(uid);
+      allow update: if isOwner(uid) || isAdmin();
+      allow delete: if isAdmin();
+
+      // Sprint 2 placeholder: KYC docs subcollection.
+      match /kycDocs/{docId} {
+        allow read:  if isOwner(uid) || isAdmin();
+        allow write: if isOwner(uid);
+      }
+    }
+
+    // ─── admins/{email} ──────────────────────────────────────────────────────
+    // Admin docs are keyed by email. An authenticated user can read their own
+    // admin doc only (for login verification). Writes go through the Firebase
+    // console — no in-app admin creation.
+    match /admins/{email} {
+      allow read:  if isSignedIn() && request.auth.token.email == email;
+      allow write: if false;
+    }
+
+    // ─── buses/{busId} ───────────────────────────────────────────────────────
+    // Buses are publicly readable so anonymous visitors can search.
+    // Only the owning operator can create. They cannot self-approve.
+    // verificationStatus and status changes are admin-only.
+    match /buses/{busId} {
+      allow read: if true;
+
+      allow create: if isSignedIn()
+        && request.resource.data.operatorId == request.auth.uid
+        && request.resource.data.verificationStatus == "pending_verification";
+
+      allow update: if
+        // Operator updates their own bus, but cannot change verificationStatus
+        // or operatorId, and cannot change status to/from "Active" themselves.
+        (isSignedIn()
+          && resource.data.operatorId == request.auth.uid
+          && request.resource.data.operatorId == resource.data.operatorId
+          && request.resource.data.verificationStatus == resource.data.verificationStatus)
+        // Admin can change anything.
+        || isAdmin();
+
+      allow delete: if isAdmin();
+    }
+
+    // ─── activeBookings/{bookingId} ──────────────────────────────────────────
+    // Read: passenger who owns the booking, operator whose bus was booked, or admin.
+    // Create: any signed-in user (their userId must match), OR operator creating
+    //         a walk-in counter booking (no userId, operatorId must match auth).
+    // Update: user can only flip status to "cancelled" on their own booking.
+    //         Operator can update bookings for buses they own. Admin can update anything.
+    // Delete: admin only.
+    match /activeBookings/{bookingId} {
+      allow read: if isSignedIn() && (
+        (resource.data.userId != null && resource.data.userId == request.auth.uid)
+        || resource.data.operatorId == request.auth.uid
+        || isAdmin()
+      );
+
+      allow create: if isSignedIn() && (
+        // User booking for themselves
+        (request.resource.data.userId == request.auth.uid)
+        // Operator walk-in booking (no user)
+        || (request.resource.data.operatorId == request.auth.uid
+            && !("userId" in request.resource.data))
+        || isAdmin()
+      );
+
+      allow update: if isSignedIn() && (
+        // User cancelling their own booking
+        (resource.data.userId != null
+          && resource.data.userId == request.auth.uid
+          && request.resource.data.userId == resource.data.userId
+          && request.resource.data.operatorId == resource.data.operatorId
+          && request.resource.data.status == "cancelled")
+        // Operator updating bookings on their own buses
+        || resource.data.operatorId == request.auth.uid
+        || isAdmin()
+      );
+
+      allow delete: if isAdmin();
+    }
+
+    // ─── Default deny ────────────────────────────────────────────────────────
+    // Anything not matched above is rejected. New collections must add
+    // explicit rules here.
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}


### PR DESCRIPTION
Previous rules allowed any authenticated user to read/write any document:
- self-approve buses by flipping verificationStatus
- read other users' profiles, phone, payment data
- modify other operators' buses and bookings
- escalate to admin if an admins doc field could be edited

New rules enforce ownership per collection, gate verificationStatus and admin actions behind the admins/{email} check, allow public read on buses (for anonymous search), and default-deny anything not explicitly matched.

firebase.json wires firestore.rules + firestore.indexes.json for deploy via firebase CLI.