### PR TITLE
feat: denormalised seatLocks collection for PII-free seat availability

### DIFF
--- a/components/operator/counter/services/active-booking.service.ts
+++ b/components/operator/counter/services/active-booking.service.ts
@@ -12,8 +12,18 @@ import {
   deleteDoc,
   serverTimestamp,
   orderBy,
+  runTransaction,
 } from "firebase/firestore";
 import { firestore } from "@/lib/firebase";
+
+// ── seatLocks helpers ─────────────────────────────────────────────────────────
+// seatLocks/{busId_date_seatNumber} is a tiny PII-free record per booked seat.
+// It exists to let anonymous users check seat availability without reading
+// activeBookings (which holds passenger PII).
+
+function seatLockId(busId: string, date: string, seatNumber: string): string {
+  return `${busId}_${date}_${seatNumber}`;
+}
 
 export interface IActiveBooking {
   id?: string;
@@ -55,19 +65,30 @@ function locationCode(s: string, n = 2): string {
   return (cleaned.slice(0, n) || "X".repeat(n)).padEnd(n, "X");
 }
 
-/** Build a candidate PNR from its parts. Always 12 chars: AABB + YYMMDD + SS.
- *  Encoding the full date (year + month + day) prevents same-route same-day
- *  collisions across months/years — e.g. May 18 and April 18 produce
- *  different PNRs without relying on the uniqueness-retry fallback. */
-function buildPNR(from: string, to: string, date: string, sequence: number): string {
+// PNR format: AABB + YYMMDD + 6 random alphanumeric chars (14 chars total).
+// 36^6 ≈ 2.1B suffixes per route/date pair. At 1000 bookings/route/day the
+// birthday-paradox collision probability is ~2.4e-4. Negligible for MVP scale,
+// which lets us generate PNRs without an existence check across activeBookings
+// (such a check would require reading other users' bookings — disallowed by
+// rules under the seatLocks design).
+const PNR_RANDOM_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"; // excludes 0/O/1/I to avoid misreads
+
+function randomSuffix(len: number): string {
+  let out = "";
+  for (let i = 0; i < len; i++) {
+    out += PNR_RANDOM_ALPHABET[Math.floor(Math.random() * PNR_RANDOM_ALPHABET.length)];
+  }
+  return out;
+}
+
+function buildPNR(from: string, to: string, date: string): string {
   const fromCode = locationCode(from, 2);
   const toCode   = locationCode(to, 2);
   const [yStr = "", mStr = "", dStr = ""] = (date || "").split("-");
   const yearPart  = (yStr || "0000").slice(-2).padStart(2, "0");
   const monthPart = String(parseInt(mStr || "1", 10) || 1).padStart(2, "0");
   const dayPart   = String(parseInt(dStr || "1", 10) || 1).padStart(2, "0");
-  const seqPart   = String(((sequence % 100) + 100) % 100).padStart(2, "0");
-  return `${fromCode}${toCode}${yearPart}${monthPart}${dayPart}${seqPart}`;
+  return `${fromCode}${toCode}${yearPart}${monthPart}${dayPart}${randomSuffix(6)}`;
 }
 
 export class ActiveBookingsService {
@@ -75,25 +96,9 @@ export class ActiveBookingsService {
     return collection(firestore, "activeBookings");
   }
 
-  /** Count this operator's bookings on a given travel date — used to seed PNR sequence. */
-  private async countOperatorBookingsOnDate(operatorId: string, date: string): Promise<number> {
-    const q = query(
-      this.col(),
-      where("operatorId", "==", operatorId),
-      where("date", "==", date)
-    );
-    const snap = await getDocs(q);
-    return snap.size;
-  }
-
-  /** Check whether a PNR is already taken. */
-  async pnrExists(pnr: string): Promise<boolean> {
-    const q = query(this.col(), where("pnr", "==", pnr));
-    const snap = await getDocs(q);
-    return !snap.empty;
-  }
-
-  /** Look up a booking by its PNR. Returns null if not found. */
+  /** Look up a booking by its PNR. Returns null if not found.
+   *  NOTE: rules require the caller to own the matching booking (user, operator,
+   *  or admin). Anonymous PNR lookups are not supported. */
   async getByPNR(pnr: string): Promise<IActiveBooking | null> {
     const normalized = (pnr || "").trim().toUpperCase();
     if (!normalized) return null;
@@ -104,71 +109,95 @@ export class ActiveBookingsService {
     return { ...(d.data() as Omit<IActiveBooking, "id">), id: d.id };
   }
 
-  /** Generate a unique PNR for a booking.
-   *  Sequence starts from this operator's booking count for the same travel date,
-   *  so it encodes "how many bookings the operator has had that day".
-   *  Falls back to random sequence (then fully random) on collision. */
-  async generatePNR(operatorId: string, from: string, to: string, date: string): Promise<string> {
-    const baseSequence = (await this.countOperatorBookingsOnDate(operatorId, date)) + 1;
-
-    // First pass: deterministic sequence, then random sequence on collision.
-    for (let attempt = 0; attempt < 20; attempt++) {
-      const seq = attempt === 0 ? baseSequence : Math.floor(Math.random() * 100);
-      const pnr = buildPNR(from, to, date, seq);
-      if (!(await this.pnrExists(pnr))) return pnr;
-    }
-
-    // Last resort — fully random PNR (still 12 chars: 4 letters + 8 digits)
-    // so length is consistent across deterministic and fallback paths. Hardly
-    // ever expected to hit — would require 20+ collisions on this route/date.
-    for (let attempt = 0; attempt < 10; attempt++) {
-      const rand = (len: number, alphabet: string) =>
-        Array.from({ length: len }, () => alphabet[Math.floor(Math.random() * alphabet.length)]).join("");
-      const pnr = rand(4, "ABCDEFGHJKLMNPQRSTUVWXYZ") + rand(8, "0123456789");
-      if (!(await this.pnrExists(pnr))) return pnr;
-    }
-    throw new Error("Could not generate a unique PNR — please retry.");
+  /** Generate a PNR. High-entropy random suffix means we skip the cross-doc
+   *  uniqueness check (which the user can't run under tightened rules anyway). */
+  generatePNR(from: string, to: string, date: string): string {
+    return buildPNR(from, to, date);
   }
 
-  /** Create a new booking (supports multiple seats). Generates a unique PNR. */
+  /** Create a new booking (supports multiple seats).
+   *
+   *  Runs as a single Firestore transaction that:
+   *   1. Reads seatLocks for each requested seat. If any already exists, throws
+   *      — that seat was just taken by a concurrent booker.
+   *   2. Writes the activeBooking doc.
+   *   3. Writes one seatLock doc per seat (deterministic ID = busId_date_seatNumber).
+   *
+   *  The rule on seatLocks/{id} requires the activeBooking referenced by
+   *  bookingId to exist after the txn, with matching ownership and busId/date
+   *  — closing the loophole where someone could lock seats without booking.
+   */
   async createActiveBooking(
     booking: Omit<IActiveBooking, "id" | "createdAt" | "updatedAt" | "pnr"> & { pnr?: string }
   ): Promise<IActiveBooking> {
-    const pnr = booking.pnr
-      || await this.generatePNR(booking.operatorId, booking.from, booking.to, booking.date);
+    const pnr = booking.pnr || this.generatePNR(booking.from, booking.to, booking.date);
+    const seats = booking.seatNumbers || [];
+    if (!seats.length) throw new Error("At least one seat is required.");
 
-    const bookingData = {
-      ...booking,
-      pnr,
-      bookingTime: serverTimestamp(),
-      createdAt: serverTimestamp(),
-      updatedAt: serverTimestamp(),
-    };
-    const ref = await addDoc(this.col(), bookingData);
-    return { ...booking, pnr, id: ref.id };
+    const bookingRef = docRef(this.col());
+    const bookingId = bookingRef.id;
+    const lockRefs = seats.map((s) =>
+      docRef(firestore, "seatLocks", seatLockId(booking.busId, booking.date, s))
+    );
+
+    await runTransaction(firestore, async (tx) => {
+      const lockSnaps = await Promise.all(lockRefs.map((r) => tx.get(r)));
+      const taken: string[] = [];
+      lockSnaps.forEach((snap, i) => { if (snap.exists()) taken.push(seats[i]); });
+      if (taken.length) {
+        throw new Error(`Seat(s) just taken: ${taken.join(", ")}. Please pick different seats.`);
+      }
+
+      const bookingData = {
+        ...booking,
+        pnr,
+        bookingTime: serverTimestamp(),
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp(),
+      };
+      tx.set(bookingRef, bookingData);
+
+      seats.forEach((seat, i) => {
+        tx.set(lockRefs[i], {
+          busId: booking.busId,
+          date: booking.date,
+          seatNumber: seat,
+          bookingId,
+          bookerUid: booking.userId || null,
+          operatorId: booking.operatorId,
+          createdAt: serverTimestamp(),
+        });
+      });
+    });
+
+    return { ...booking, pnr, id: bookingId };
+  }
+
+  /** Delete all seatLocks for a given booking. Safe to call multiple times;
+   *  missing locks are no-ops. Used by cancellation. */
+  private async releaseSeatLocks(busId: string, date: string, seats: string[]): Promise<void> {
+    await Promise.all(
+      seats.map(async (s) => {
+        try {
+          await deleteDoc(docRef(firestore, "seatLocks", seatLockId(busId, date, s)));
+        } catch {
+          // Lock didn't exist or was already freed — fine.
+        }
+      })
+    );
   }
 
   /** Get all booked seat labels for a bus on a specific date.
-   *  Handles both legacy docs (seatNumber: string) and new docs (seatNumbers: string[]). */
+   *  Reads from the PII-free seatLocks collection so this works for anonymous
+   *  visitors (needed for the booking flow's seat availability check). */
   async getBookedSeats(busId: string, date: string): Promise<string[]> {
     const q = query(
-      this.col(),
+      collection(firestore, "seatLocks"),
       where("busId", "==", busId),
-      where("date", "==", date),
-      where("status", "==", "booked")
+      where("date", "==", date)
     );
     const snap = await getDocs(q);
-    const booked: string[] = [];
-    snap.docs.forEach((d) => {
-      const data = d.data();
-      if (Array.isArray(data.seatNumbers) && data.seatNumbers.length) {
-        booked.push(...data.seatNumbers);
-      } else if (data.seatNumber) {
-        // legacy single-seat booking
-        booked.push(data.seatNumber);
-      }
-    });
-    return booked;
+    return snap.docs.map((d) => d.data().seatNumber as string);
   }
 
   /** Check whether a single seat is still free */
@@ -230,15 +259,32 @@ export class ActiveBookingsService {
     return { ...(updated.data() as Omit<IActiveBooking, "id">), id: updated.id };
   }
 
-  /** Cancel a booking */
+  /** Cancel a booking. Flips status to "cancelled" AND releases the seatLocks
+   *  so the seats become bookable again. */
   async cancelActiveBooking(id: string): Promise<void> {
     const ref = docRef(firestore, "activeBookings", id);
+    const snap = await getDoc(ref);
+    if (!snap.exists()) return;
+    const data = snap.data() as IActiveBooking;
     await updateDoc(ref, { status: "cancelled", updatedAt: serverTimestamp() });
+    const seats = data.seatNumbers && data.seatNumbers.length
+      ? data.seatNumbers
+      : (data.seatNumber ? [data.seatNumber] : []);
+    if (seats.length) await this.releaseSeatLocks(data.busId, data.date, seats);
   }
 
-  /** Hard-delete a booking */
+  /** Hard-delete a booking. Also releases seatLocks. */
   async deleteActiveBooking(id: string): Promise<void> {
-    await deleteDoc(docRef(firestore, "activeBookings", id));
+    const ref = docRef(firestore, "activeBookings", id);
+    const snap = await getDoc(ref);
+    if (snap.exists()) {
+      const data = snap.data() as IActiveBooking;
+      const seats = data.seatNumbers && data.seatNumbers.length
+        ? data.seatNumbers
+        : (data.seatNumber ? [data.seatNumber] : []);
+      if (seats.length) await this.releaseSeatLocks(data.busId, data.date, seats);
+    }
+    await deleteDoc(ref);
   }
 
   /** Fetch a single booking by ID */

--- a/firestore.rules
+++ b/firestore.rules
@@ -81,38 +81,85 @@ service cloud.firestore {
     // Read: passenger who owns the booking, operator whose bus was booked, or admin.
     // Create: any signed-in user (their userId must match), OR operator creating
     //         a walk-in counter booking (no userId, operatorId must match auth).
-    // Update: user can only flip status to "cancelled" on their own booking.
-    //         Operator can update bookings for buses they own. Admin can update anything.
+    // Update: user can flip status to "cancelled" or "completed" on their own
+    //         booking, nothing else. Operator can update bookings on their buses.
+    //         Admin can update anything.
     // Delete: admin only.
     match /activeBookings/{bookingId} {
       allow read: if isSignedIn() && (
-        (resource.data.userId != null && resource.data.userId == request.auth.uid)
+        resource.data.userId == request.auth.uid
         || resource.data.operatorId == request.auth.uid
         || isAdmin()
       );
 
       allow create: if isSignedIn() && (
         // User booking for themselves
-        (request.resource.data.userId == request.auth.uid)
-        // Operator walk-in booking (no user)
+        request.resource.data.userId == request.auth.uid
+        // Operator walk-in booking (no userId)
         || (request.resource.data.operatorId == request.auth.uid
             && !("userId" in request.resource.data))
         || isAdmin()
       );
 
       allow update: if isSignedIn() && (
-        // User cancelling their own booking
-        (resource.data.userId != null
-          && resource.data.userId == request.auth.uid
+        // User updating their own booking — status only, identity fields locked
+        (resource.data.userId == request.auth.uid
           && request.resource.data.userId == resource.data.userId
           && request.resource.data.operatorId == resource.data.operatorId
-          && request.resource.data.status == "cancelled")
+          && request.resource.data.busId == resource.data.busId
+          && request.resource.data.status in ["cancelled", "completed"])
         // Operator updating bookings on their own buses
         || resource.data.operatorId == request.auth.uid
         || isAdmin()
       );
 
       allow delete: if isAdmin();
+    }
+
+    // ─── seatLocks/{busId_date_seatNumber} ───────────────────────────────────
+    // Denormalised seat-availability cache. Holds only busId, date, seatNumber,
+    // bookingId, bookerUid, operatorId — no passenger PII.
+    //
+    // Doc ID is deterministic: "{busId}_{date}_{seatNumber}". This both gives
+    // us cheap key lookups AND makes double-booking structurally impossible
+    // (a transaction trying to create an existing doc fails).
+    //
+    // Reads are public so the booking flow can check seat availability without
+    // touching activeBookings (which holds PII).
+    //
+    // Writes are gated on a corresponding activeBooking being created in the
+    // SAME transaction with matching busId, date, and ownership.
+    match /seatLocks/{lockId} {
+      allow read: if true;
+
+      allow create: if isSignedIn()
+        && request.resource.data.busId is string
+        && request.resource.data.date is string
+        && request.resource.data.seatNumber is string
+        && request.resource.data.bookingId is string
+        && request.resource.data.operatorId is string
+        // The activeBooking referenced must exist after the transaction and
+        // must match the seatLock's busId/date.
+        && getAfter(/databases/$(database)/documents/activeBookings/$(request.resource.data.bookingId)).data.busId == request.resource.data.busId
+        && getAfter(/databases/$(database)/documents/activeBookings/$(request.resource.data.bookingId)).data.date == request.resource.data.date
+        // The activeBooking must be owned by the requester — as user OR as operator walk-in.
+        && (
+          // User booking — userId matches auth.uid
+          (getAfter(/databases/$(database)/documents/activeBookings/$(request.resource.data.bookingId)).data.userId == request.auth.uid
+            && request.resource.data.bookerUid == request.auth.uid)
+          // Operator walk-in — operatorId matches auth.uid, no bookerUid required
+          || getAfter(/databases/$(database)/documents/activeBookings/$(request.resource.data.bookingId)).data.operatorId == request.auth.uid
+        );
+
+      // Locks are immutable while held — to "release" a seat you delete the lock.
+      allow update: if false;
+
+      // Delete: the user who booked it, the operator of the bus, or admin.
+      allow delete: if isSignedIn() && (
+        ("bookerUid" in resource.data && resource.data.bookerUid == request.auth.uid)
+        || resource.data.operatorId == request.auth.uid
+        || isAdmin()
+      );
     }
 
     // ─── Default deny ────────────────────────────────────────────────────────

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/scripts/migrate-seat-locks.mjs
+++ b/scripts/migrate-seat-locks.mjs
@@ -1,0 +1,84 @@
+// One-off migration: backfill seatLocks/{busId_date_seatNumber} for every
+// existing activeBooking with status="booked", so the new seat-availability
+// check (which reads seatLocks) sees pre-existing reservations.
+//
+// Run with: node --env-file=.env.preview scripts/migrate-seat-locks.mjs
+// Then:     node --env-file=.env.production scripts/migrate-seat-locks.mjs
+//
+// Safe to re-run — existing seatLocks are skipped, never overwritten.
+
+import { initializeApp, cert } from "firebase-admin/app";
+import { getFirestore, FieldValue } from "firebase-admin/firestore";
+
+const projectId  = process.env.FIREBASE_PROJECT_ID;
+const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
+const rawKey     = process.env.FIREBASE_PRIVATE_KEY;
+
+if (!projectId || !clientEmail || !rawKey) {
+  console.error("Missing FIREBASE_PROJECT_ID / FIREBASE_CLIENT_EMAIL / FIREBASE_PRIVATE_KEY.");
+  console.error("Run with: node --env-file=.env.preview scripts/migrate-seat-locks.mjs");
+  process.exit(1);
+}
+
+const privateKey = rawKey.replace(/\\n/g, "\n");
+
+initializeApp({
+  credential: cert({ projectId, clientEmail, privateKey }),
+});
+
+const db = getFirestore();
+
+console.log(`→ Connected to project: ${projectId}`);
+
+const snap = await db
+  .collection("activeBookings")
+  .where("status", "==", "booked")
+  .get();
+
+console.log(`→ Found ${snap.size} booked activeBookings to scan`);
+
+let created = 0;
+let skipped = 0;
+let malformed = 0;
+
+for (const doc of snap.docs) {
+  const data = doc.data();
+  const { busId, date, seatNumbers, seatNumber, operatorId, userId } = data;
+  if (!busId || !date || !operatorId) {
+    console.warn(`  ⚠ booking ${doc.id} missing busId/date/operatorId — skipping`);
+    malformed++;
+    continue;
+  }
+  const seats = Array.isArray(seatNumbers) && seatNumbers.length
+    ? seatNumbers
+    : (seatNumber ? [seatNumber] : []);
+  if (!seats.length) {
+    console.warn(`  ⚠ booking ${doc.id} has no seats — skipping`);
+    malformed++;
+    continue;
+  }
+
+  for (const seat of seats) {
+    const lockId = `${busId}_${date}_${seat}`;
+    const lockRef = db.collection("seatLocks").doc(lockId);
+    const existing = await lockRef.get();
+    if (existing.exists) {
+      skipped++;
+      continue;
+    }
+    await lockRef.set({
+      busId,
+      date,
+      seatNumber: seat,
+      bookingId: doc.id,
+      bookerUid: userId || null,
+      operatorId,
+      createdAt: FieldValue.serverTimestamp(),
+    });
+    created++;
+  }
+}
+
+console.log("");
+console.log(`✓ Done. Created ${created}, skipped ${skipped} (already existed), malformed ${malformed}.`);
+process.exit(0);


### PR DESCRIPTION
Previously the booking flow's seat availability check queried activeBookings directly. With activeBookings tightened to owner-only reads, that query failed for anonymous/regular users — making booking impossible.

New design: seatLocks/{busId_date_seatNumber} holds only the bus/date/seat triple plus bookerUid/operatorId for cancellation. Public-read, write-only as part of a transactional booking. Activebookings stays strictly owner-only and can hold whatever PII/payment data we add in future sprints.

Booking creation runs as a Firestore transaction over both collections, making double-booking structurally impossible (deterministic seatLock IDs collide on a race). Cancellation/deletion releases the locks.

PNR generation switched from sequence-count + uniqueness-check (both required broad reads on activeBookings) to a 6-char alphanumeric suffix from a 32-char alphabet (collision probability negligible at MVP scale).

Also includes scripts/migrate-seat-locks.mjs for backfilling seatLocks on projects that already have booked activeBookings (not needed for sprint-0 dev — wiped — kept for prod onboarding day).