### PR TITLE
chore: keep dev.uthbus.com out of search engines; trim tracker hero

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,6 +1,14 @@
 import type { MetadataRoute } from "next"
 
 export default function robots(): MetadataRoute.Robots {
+  // Anything that isn't the live production deploy (uthbus.com) should be
+  // completely invisible to crawlers — dev.uthbus.com, preview URLs, etc.
+  if (process.env.VERCEL_ENV && process.env.VERCEL_ENV !== "production") {
+    return {
+      rules: [{ userAgent: "*", disallow: "/" }],
+    }
+  }
+
   return {
     rules: [
       {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -11,6 +11,22 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  async headers() {
+    // Block all crawlers on every non-production deploy (dev.uthbus.com,
+    // preview URLs, etc.) at the HTTP layer. Covers static assets that
+    // don't honour <meta name="robots"> — images, PDFs, etc.
+    if (process.env.VERCEL_ENV && process.env.VERCEL_ENV !== "production") {
+      return [
+        {
+          source: "/:path*",
+          headers: [
+            { key: "X-Robots-Tag", value: "noindex, nofollow, noarchive" },
+          ],
+        },
+      ]
+    }
+    return []
+  },
 }
 
 export default withSentryConfig(nextConfig, {

--- a/public/tracker.html
+++ b/public/tracker.html
@@ -3,7 +3,9 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>UTHBUS — BA Handover & Sprint Plan</title>
+<meta name="robots" content="noindex, nofollow, noarchive" />
+<meta name="googlebot" content="noindex, nofollow, noarchive" />
+<title>UTHBUS — Internal Tracker</title>
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
@@ -539,21 +541,6 @@
     <span class="date" id="lastUpdatedNav">Updated <span data-last-updated>—</span></span>
   </div>
 </nav>
-
-<!-- ============ COVER ============ -->
-<div class="cover">
-  <div class="wrap">
-    <div class="logo"><span class="uth">uth</span><span class="bus">bus</span></div>
-    <h1>BA Handover &amp;<br/>Engineering Sprint Plan</h1>
-    <p class="sub">A feature-by-feature specification of the platform as it stands today, what is still pending, and a phased sprint plan to take UTHBUS from "looks finished" to actually shippable as a trustworthy marketplace.</p>
-    <div class="meta">
-      <span>Owner: <b>CTO &middot; Solo Builder</b></span>
-      <span>Audience: <b>Future self (and the team I will hire)</b></span>
-      <span>Branch: <b>main</b></span>
-      <span>Doc Version: <b>1.1 (solo) &middot; 2026-06-05</b></span>
-    </div>
-  </div>
-</div>
 
 <div class="wrap">
 


### PR DESCRIPTION
Three coordinated changes so dev/preview deploys never get indexed and the tracker is leaner.

- next.config.mjs: async headers() returns X-Robots-Tag: noindex, nofollow, noarchive on every response when VERCEL_ENV !== 'production'. Covers static assets that don't honour <meta name="robots"> (images, PDFs).
- app/robots.ts: same env check — serves Disallow: / for non-prod builds, unchanged allow list for production.
- public/tracker.html: dropped the navy cover/hero block (logo, title, meta strip) — redundant with the sticky nav. Page now opens straight to the dashboard. Also added <meta name="robots"> and googlebot noindex tags as a third belt-and-suspenders layer.

Net effect: dev.uthbus.com, preview-*.vercel.app, and the tracker itself are all explicitly excluded from Google. uthbus.com indexing unchanged.